### PR TITLE
Small documentation fixes

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -15,9 +15,8 @@ class ExternalModule extends AbstractExternalModule {
      * @inheritdoc
      */
     function hook_every_page_top($project_id) {
-        if (PAGE == 'Design/online_designer.php' && $project_id) {
+        if ($project_id) {
             $this->includeJs('js/modify_help_menu.js');
-            return;
         }
 
         //if not on a data entry page or survey, then don't do anything

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-# hide_choice_by_event
+# Hide Choice by Event
 A REDCap module that implements an action tag to hide a categorical field choice on a specified list of events.
 
 ## Prerequisites
-- [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules)
+- REDCap >= 8.0.3
 
-## Installation
-- Clone this repo into to `<redcap-root>/modules/hide_choice_by_event_v<version_number>`.
-- Go to **Control Center > Manage External Modules** and enable Hide Choice By Event.
-- For each project you want to use this module, go to the project home page, click on **Manage External Modules** link, and then enable the Hide Choice By Event module for that project.
+## Easy Installation
+- Obtain this module from the Consortium [REDCap Repo](https://redcap.vanderbilt.edu/consortium/modules/index.php) from the Control Center.
+
+## Manual Installation
+- Clone this repo into `<redcap-root>/modules/hide_choice_by_event_v<version_number>`.
+- Go to **Control Center > Manage External Modules** and enable Hide Choice by Event.
 
 ## How to use
-Once the module is activated on a project, the @HIDE-CHOICE-BY-EVENT tag will be available in the action tag help text of the Online Designer. Add @HIDE-CHOICE-BY-EVENT to any categorical field where you would like to hide some of the choices based on the event.
+Go to your project home page, click on Manage External Modules link, and then enable Hide Choice by Event.
+
+Once the module is activated on a project, the `@HIDE-CHOICE-BY-EVENT` tag will be available in the action tag help text of the Online Designer. Add `@HIDE-CHOICE-BY-EVENT` to any categorical field where you would like to hide some of the choices based on the event.
 
 As an argument you will need to provide a JSON object that tells the tag which choice to hide on which event. It should look something like this:
 ```

--- a/js/modify_help_menu.js
+++ b/js/modify_help_menu.js
@@ -1,9 +1,4 @@
 $(document).ready(function() {
-    // Checking if field annotation is present on this page.
-    if ($('#div_field_annotation').length === 0) {
-        return false;
-    }
-
     $('body').on('dialogopen', function(event, ui) {
         var $popup = $(event.target);
         if ($popup.prop('id') !== 'action_tag_explain_popup') {
@@ -11,12 +6,12 @@ $(document).ready(function() {
             return false;
         }
 
-        // Aux function that checks if text matches the "@DEFAULT" string.
+        // Aux function that checks if text matches the "@HIDECHOICE" string.
         var isDefaultLabelColumn = function() {
             return $(this).text() === '@HIDECHOICE';
         }
 
-        // Getting @DEFAULT row from action tags help table.
+        // Getting @HIDECHOICE row from action tags help table.
         var $default_action_tag = $popup.find('td').filter(isDefaultLabelColumn).parent();
         if ($default_action_tag.length !== 1) {
             return false;

--- a/js/modify_help_menu.js
+++ b/js/modify_help_menu.js
@@ -26,7 +26,10 @@ $(document).ready(function() {
         var $button = $cols.find('button');
 
         // Column 1: updating button behavior.
-        $button.attr('onclick', $button.attr('onclick').replace('@HIDECHOICE', tag_name));
+        if ($button.length !== 0) {
+            $button.attr('onclick', $button.attr('onclick').replace('@HIDECHOICE', tag_name));    
+        }
+        
 
         // Columns 2: updating action tag label.
         $cols.filter(isDefaultLabelColumn).text(tag_name);


### PR DESCRIPTION
- Adding "Easy installation" section on README
- Including `@HIDE-CHOICE-BY-EVENT` on every action tag popup (instead of including only on Online Designer - to test this, go to Project Setup and click on the action tag helper button)