### PR TITLE
Exclude action tags that follow @HIDE-CHOICE-BY-EVENT's parameter

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -44,6 +44,7 @@ class ExternalModule extends AbstractExternalModule {
             if (preg_match('/@HIDE-CHOICE-BY-EVENT\s*=\s*(\[)/', $action_tags, $matches, PREG_OFFSET_CAPTURE)) {
                 $count = 1;
                 $json_start = $matches[1][1];
+                $json_len = 0;
                 $len = strlen($action_tags);
 
                 for ($i = $json_start + 1; $i < $len; $i++) {
@@ -56,7 +57,7 @@ class ExternalModule extends AbstractExternalModule {
                     }
                 }
 
-                if (!isset($json_len)) {
+                if (!$json_len) {
                     continue;
                 }
 

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -41,7 +41,7 @@ class ExternalModule extends AbstractExternalModule {
             //check if @HIDE-CHOICE-BY-EVENT is among action tags.
             //did not use \Form::getValueInActionTag methods because of nested
             //quotes inside JSON.
-            if (preg_match("/@HIDE-CHOICE-BY-EVENT\s*=\s*(\[.*\])/", $action_tags, $matches)) {
+            if (preg_match("/@HIDE-CHOICE-BY-EVENT\s*=\s*(\[[^@]*\])/", $action_tags, $matches)) {
 
                     //add to settings variable if it is a valid json
                     if ($json_config = json_decode($matches[1], true)) {

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -41,12 +41,29 @@ class ExternalModule extends AbstractExternalModule {
             //check if @HIDE-CHOICE-BY-EVENT is among action tags.
             //did not use \Form::getValueInActionTag methods because of nested
             //quotes inside JSON.
-            if (preg_match("/@HIDE-CHOICE-BY-EVENT\s*=\s*(\[[^@]*\])/", $action_tags, $matches)) {
+            if (preg_match('/@HIDE-CHOICE-BY-EVENT\s*=\s*(\[)/', $action_tags, $matches, PREG_OFFSET_CAPTURE)) {
+                $count = 1;
+                $json_start = $matches[1][1];
+                $len = strlen($action_tags);
 
-                    //add to settings variable if it is a valid json
-                    if ($json_config = json_decode($matches[1], true)) {
-                        $settings[$field] = $json_config;
+                for ($i = $json_start + 1; $i < $len; $i++) {
+                    if ($action_tags[$i] == '[') {
+                        $count++;
                     }
+                    elseif ($action_tags[$i] == ']' && !--$count) {
+                        $json_len = $i - $json_start + 1;
+                        break;
+                    }
+                }
+
+                if (!isset($json_len)) {
+                    continue;
+                }
+
+                //add to settings variable if it is a valid json
+                if ($json_config = json_decode(substr($action_tags, $json_start, $json_len), true)) {
+                    $settings[$field] = $json_config;
+                }
             }
 
         }


### PR DESCRIPTION
To test this PR, follow these steps:

- [x] Enable the module on a project
- [x] Configure a field to use according to the README.
- [x] Follow @HIDE-CHOICE-BY-EVENT's parameter--the JSON blob with other action tags as in the example below

```
@HIDE-CHOICE-BY-EVENT = [
    {
        "code": "R000010105",
        "event": ["baseline_arm_1", "followup_month_3_arm_1"]
    }
]
@DEFAULT='R000010104' @DEFAULT_1='[sa3_atorva_dd]'
```

This PR addresses issue #3 